### PR TITLE
fix README typo

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
 official-artwork
 ================
 
-Official logo's of Archwomen
+Official logos of Archwomen


### PR DESCRIPTION
There's no apostrophe before 's' in normal plurals.
